### PR TITLE
Removed chmod on robo symlink

### DIFF
--- a/src/AbstractRoboFile.php
+++ b/src/AbstractRoboFile.php
@@ -935,10 +935,6 @@ abstract class AbstractRoboFile extends \Robo\Tasks implements DigipolisProperti
             ->destinationFolder($releaseDir)
             ->package($archive);
 
-        $collection->taskSsh($worker, $auth)
-            ->remoteDirectory($releaseDir, true)
-            ->exec('chmod u+rx vendor/bin/robo');
-
         return $collection;
     }
 


### PR DESCRIPTION
Not sure if this chmod is still needed. Composer should handle the permission for that file imo.