### PR TITLE
Allow overriding remote settings per environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,14 @@ remote:
   # Here you can specify the overrides per evironment. This example uses the
   # default regex matcher.
   environment_overrides:
-    # Here you can specify your overrides. The keys are the values to match
-    # against the value of the specified environment variable, using the
-    # specified matcher. Since this example uses the regex matcher, we specified
-    # a PCRE regular expression. The values can be anything under the `remote`
-    # key in this specification, and will override said setting for the matching
-    # environment. Only the first match is used (top to bottom).
+    # List your overrides here.
+    # The keys will be matched against the value of `environment_env_var` via
+    # `environment_matcher`.
+    # The default properties use regexMatch and thus the keys here are PCRE
+    # regexes.
+    # The values per key can be anything set in `remote` and will override that
+    # setting.
+    # Only the first match is used (top to bottom).
     ^qa:
       cleandir_limit: 3
     ^staging:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ remote:
   # ${remote.releasesdir}. This value determines how many past releases we
   # should keep.
   cleandir_limit: 5
+  # We allow overriding settings under the `remote` key in properties.yml by
+  # environment. This means we need to have a reliable way to determine which
+  # environment we're currently on. We use the value of an environment variable
+  # to determine the environment. This variable defaults to HOSTNAME.
+  environment_env_var: HOSTNAME
+  # We use an environment matcher to match the value of the environment variable
+  # mentioned above, to the overrides that need to be applied (see
+  # `environment_overrides` below. This needs to be a PHP callable, and defaults
+  # to `\DigipolisGent\Robo\Helpers\Util\EnvironmentMatcher::regexMatch` to
+  # match the value by using a regular expression.
+  # `\DigipolisGent\Robo\Helpers\Util\EnvironmentMatcher::literalMatch` is also
+  # available to match by a literal value. You can of course also implement your
+  # own.
+  environment_matcher: '\DigipolisGent\Robo\Helpers\Util\EnvironmentMatcher::regexMatch'
+  # Here you can specify the overrides per evironment. This example uses the
+  # default regex matcher.
+  environment_overrides:
+    # Here you can specify your overrides. The keys are the values to match
+    # against the value of the specified environment variable, using the
+    # specified matcher. Since this example uses the regex matcher, we specified
+    # a PCRE regular expression. The values can be anything under the `remote`
+    # key in this specification, and will override said setting for the matching
+    # environment. Only the first match is used (top to bottom).
+    ^qa:
+      cleandir_limit: 3
+    ^staging:
+      cleandir_limit: 2
 # We use the phpseclib library to execute our ssh commands. Their default
 # timeout is 10 seconds. Some tasks take longer than that, so we make the
 # timeouts configurable. Below are the configurable timeouts. The values used in

--- a/src/Traits/AbstractCommandTrait.php
+++ b/src/Traits/AbstractCommandTrait.php
@@ -19,6 +19,11 @@ trait AbstractCommandTrait
     use \Robo\Task\Base\loadTasks;
     use TraitDependencyCheckerTrait;
 
+    public static $defaultEnvironmentOverrideSettings = [
+        'environment_env_var' => 'HOSTNAME',
+        'environment_matcher' => '\\DigipolisGent\\Robo\\Helpers\\Util\\EnvironmentMatcher::regexMatch',
+    ];
+
     /**
      * Stores the request time.
      *
@@ -102,23 +107,12 @@ trait AbstractCommandTrait
      */
     protected function processEnvironmentOverrides($settings)
     {
-        $defaults = [
-            'environment_env_var' => 'HOSTNAME',
-            'environment_matcher' => '\\DigipolisGent\\Robo\\Helpers\\Util\\EnvironmentMatcher::regexMatch',
-        ];
-        $settings += $defaults;
+        $settings += static::$defaultEnvironmentOverrideSettings;
         if (!isset($settings['environment_overrides']) || !$settings['environment_overrides']) {
             return $settings;
         }
 
-        // Get the first server in the list.
-        $server = false;
-        foreach ($settings as $key => $value) {
-            if (preg_match('/^server/', $key) === 1) {
-              $server = $value;
-              continue;
-            }
-        }
+        $server = $this->getFirstServer($settings);
         if (!$server) {
             return $settings;
         }
@@ -144,6 +138,26 @@ trait AbstractCommandTrait
             }
         }
         return $settings;
+    }
+
+    /**
+     * Get the first server entry from the remote settings.
+     *
+     * @param array $settings
+     *
+     * @return string|bool
+     *   First server if found, false otherwise.
+     *
+     * @see self::processEnvironmentOverrides
+     */
+    protected function getFirstServer($settings)
+    {
+        foreach ($settings as $key => $value) {
+            if (preg_match('/^server/', $key) === 1) {
+              return $value;
+            }
+        }
+        return false;
     }
 
 

--- a/src/Traits/AbstractCommandTrait.php
+++ b/src/Traits/AbstractCommandTrait.php
@@ -154,7 +154,7 @@ trait AbstractCommandTrait
     {
         foreach ($settings as $key => $value) {
             if (preg_match('/^server/', $key) === 1) {
-              return $value;
+                return $value;
             }
         }
         return false;

--- a/src/Util/EnvironmentMatcher.php
+++ b/src/Util/EnvironmentMatcher.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DigipolisGent\Robo\Helpers\Util;
+
+/**
+ * Class EnvironmentMatcher.
+ */
+class EnvironmentMatcher
+{
+    public static function regexMatch($environmentMatch, $envVarValue)
+    {
+        return preg_match('/' . $environmentMatch . '/', $envVarValue) === 1;
+    }
+
+    public static function literalMatch($environmentMatch, $envVarValue)
+    {
+        return $environmentMatch === $envVarValue;
+    }
+}


### PR DESCRIPTION
Allow overriding remote settings per environment in the properties.yml
file. Itmakes sense for some settings to differ between environments.
For example the `cleandir_limit` setting. It makes sense to maintain
only one or two releases on staging to minimize storage, but to maintain
three or even more releases on production to be able to rollback when
things go wrong.