### PR TITLE
Clear cache after remote sync if applicable.

### DIFF
--- a/src/Traits/AbstractSyncRemoteCommandTrait.php
+++ b/src/Traits/AbstractSyncRemoteCommandTrait.php
@@ -165,6 +165,10 @@ trait AbstractSyncRemoteCommandTrait
             );
         }
 
+        if ($clearCache = $this->clearCacheTask($destinationHost, $destinationAuth, $destinationRemote)) {
+            $collection->completion($clearCache);
+        }
+
         return $collection;
     }
 


### PR DESCRIPTION
We weren't clearing caches after a `*_sync_prod_to_{dv,qa}` job in
Jenkins.

Closes #32