### PR TITLE
Add support for php 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 env:
   global:
     - CC_TEST_REPORTER_ID=2f97c2ecce1be2d3a4aea4825bfde2709b64378dac708c1437115b63e30fe942

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ env:
     - CC_TEST_REPORTER_ID=2f97c2ecce1be2d3a4aea4825bfde2709b64378dac708c1437115b63e30fe942
 language: php
 php:
-  - 7.1
-  - 7.2
-  - 7.3
+  - 7.4
+  - 8.1.0
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "digipolisgent/robo-digipolis-general": "^1.0",
         "gordalina/cachetool": "^8|^7|^6|^5|^4|^3",
         "digipolisgent/command-builder": "^1.2.1",
-        "roave/better-reflection": "~4.3.0|^3.0|^2.0"
+        "roave/better-reflection": "^5.0|~4.3.0|^3.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "roave/better-reflection": "^5.0|~4.3.0|^3.0|^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
->
-    <testsuites>
-        <testsuite name="robo-digipolis-helpers tests">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="robo-digipolis-helpers tests">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/tests/Readme.md
+++ b/tests/Readme.md
@@ -1,0 +1,1 @@
+Add tests here


### PR DESCRIPTION
``` 
 Problem 1
    - roave/better-reflection 4.3.0 requires php >=7.2.0,<7.5.0 -> your php version (8.1.0; overridden via config.platform, actual: 8.1.2) does not satisfy that requirement.
    - digipolisgent/robo-digipolis-drupal8 2.0.2 requires digipolisgent/robo-digipolis-helpers ^2.0 -> satisfiable by digipolisgent/robo-digipolis-helpers[2.1.3].
    - digipolisgent/robo-digipolis-helpers 2.1.3 requires roave/better-reflection ~4.3.0|^3.0|^2.0 -> satisfiable by roave/better-reflection[4.3.0].
    - digipolisgent/robo-digipolis-drupal8 is locked to version 2.0.2 and an update of this package was not requested.
```